### PR TITLE
feat(scmPush) : added branch parameter for push task

### DIFF
--- a/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/core/BaseScmAdapter.groovy
+++ b/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/core/BaseScmAdapter.groovy
@@ -22,7 +22,7 @@ interface BaseScmAdapter {
 
     String merge(String from)
 
-    String push()
+    String push(String branch)
 
     List<String> generateGitCommand(List<String> command)
 

--- a/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/core/GitAdapter.groovy
+++ b/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/core/GitAdapter.groovy
@@ -76,8 +76,8 @@ class GitAdapter extends Executor implements BaseScmAdapter {
     }
 
     @Override
-    String push() {
-        def result = exec(generateGitCommand(['git', 'push', '-u', 'origin', branchToUse != null ? branchToUse : 'master']), directory: project.rootDir, errorMessage: ' Failed to push to remote ', errorPatterns: ['[rejected] ', ' error: ', ' fatal: '])
+    String push(String branch) {
+        def result = exec(generateGitCommand(['git', 'push', '-u', 'origin', branch != null ? branch : branchToUse != null ? branchToUse : "master"]), directory: project.rootDir, errorMessage: ' Failed to push to remote ', errorPatterns: ['[rejected] ', ' error: ', ' fatal: '])
         return result
     }
 

--- a/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/entities/Flow.groovy
+++ b/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/entities/Flow.groovy
@@ -73,8 +73,8 @@ class Flow {
         createTask(MergeTask, [from: branch])
     }
 
-    def push() {
-        createTask(PushTask, null)
+    def push(String branch) {
+        createTask(PushTask, [branch: branch])
     }
 
     def delete(String branchName) {

--- a/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/tasks/scm/PushTask.groovy
+++ b/delivery-plugin/src/main/groovy/com/leroymerlin/plugins/tasks/scm/PushTask.groovy
@@ -7,8 +7,10 @@ import org.gradle.api.tasks.TaskAction
  */
 class PushTask extends ScmBaseTask {
 
+    String branch
+
     @TaskAction
     push() {
-        scmAdapter.push()
+        scmAdapter.push(branch)
     }
 }


### PR DESCRIPTION
Added branch parameter to git push task.
It will facilitate flows if working on multi-branch jenkins pipeline for example.

If not specified, the task will fall back to old system (that requires to call `switchBranch` before use).